### PR TITLE
RawGit Shutting Down Soon

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ npm install minhash --save
 If you prefer, you can instead load the package directly in a browser:
 
 ```html
-<script src='https://rawgit.com/duhaime/minhash/master/minhash.min.js'></script>
+<script src='https://cdn.jsdelivr.net/gh/duhaime/minhash@master/minhash.min.js'></script>
 ```
 
 #### Minhash Usage


### PR DESCRIPTION
According to [RawGit](https://rawgit.com/), it's shutting down soon, and it suggested [JSDilvr](https://www.jsdelivr.com/rawgit), which I changed to make things work.

> RawGit is now in a sunset phase and will soon shut down. It's been a fun five years, but all things must end.
GitHub repositories that served content through RawGit within the last month will continue to be served until at least October of 2019. URLs for other repositories are no longer being served.
If you're currently using RawGit, please stop using it as soon as you can.